### PR TITLE
Point edit/view links to master branch, not hexo/relaunch branches

### DIFF
--- a/source/_posts/announcing-elements.md
+++ b/source/_posts/announcing-elements.md
@@ -1,8 +1,8 @@
 ---
 title: Announcing the New Elements Project
 subtitle: Open source code and developer sidechains for advancing Bitcoin.
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/_posts/announcing-elements.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/_posts/announcing-elements.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/_posts/announcing-elements.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/_posts/announcing-elements.md
 author: martindale
 ---
 

--- a/source/case-studies/gem.md
+++ b/source/case-studies/gem.md
@@ -1,8 +1,8 @@
 ---
 title: Gem's Use of Elements & Sidechains
 description: Learn about how Gem is using Elements in their sidechain implementation.
-source: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/case-studies/gem.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/case-studies/gem.md
+source: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/case-studies/gem.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/case-studies/gem.md
 ---
 
 

--- a/source/case-studies/index.md
+++ b/source/case-studies/index.md
@@ -1,8 +1,8 @@
 ---
 title: Who is using Elements?
 description: Case studies of Elements Project users and deployments.
-source: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/case-studies/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/case-studies/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/case-studies/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/case-studies/index.md
 ---
 
 ### Gem

--- a/source/contributing/index.md
+++ b/source/contributing/index.md
@@ -1,8 +1,8 @@
 ---
 title: Get Involved.
 subtitle: Contributing to the Elements Project
-source: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/contributing/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/contributing/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/contributing/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/contributing/index.md
 ---
 
 <div class="ui vertical stripe segment" style="padding: 0; border: 0; margin-bottom: 3em;">

--- a/source/elements/asset-issuance/index.md
+++ b/source/elements/asset-issuance/index.md
@@ -3,8 +3,8 @@ title: Basic Asset Issuance
 description: Create new assets on a sidechain by using Bitcoin as a bond.
 image: /img/asset-issuance.svg
 branch: multi-asset-0.11
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/asset-issuance/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/asset-issuance/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/asset-issuance/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/asset-issuance/index.md
 ---
 
 *Principal Investigator: Jorge Timón*

--- a/source/elements/bitmask-sighash-modes/index.md
+++ b/source/elements/bitmask-sighash-modes/index.md
@@ -2,8 +2,8 @@
 title: Bitmask Sighash Modes
 description: Allow arbitrary, miner-rewritable bitmasks of transaction inputs and outputs.
 image: /img/bitmask-sighash-modes.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/bitmask-sighash-modes/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/bitmask-sighash-modes/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/bitmask-sighash-modes/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/bitmask-sighash-modes/index.md
 ---
 
 *Principal Investigator: Glenn Willen*

--- a/source/elements/confidential-transactions/index.md
+++ b/source/elements/confidential-transactions/index.md
@@ -2,8 +2,8 @@
 title: Confidential Transactions
 description: Preserve security while simultaneously obscuring transaction values.
 image: /img/confidential-transactions.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/confidential-transactions/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/confidential-transactions/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/confidential-transactions/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/confidential-transactions/index.md
 ---
 
 One of the most powerful new features being explored in Elements is Confidential

--- a/source/elements/deterministic-pegs/index.md
+++ b/source/elements/deterministic-pegs/index.md
@@ -2,8 +2,8 @@
 title: Deterministic Pegs
 description: Deterministic Pegs allow cross-chain transactions to be constructed in a decentralized fashion.  Tokens can be moved from one blockchain to another.
 image: /img/deterministic-pegs.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/deterministic-pegs/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/deterministic-pegs/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/deterministic-pegs/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/deterministic-pegs/index.md
 ---
 
 *Principal Investigator: Matt Corallo*

--- a/source/elements/index.md
+++ b/source/elements/index.md
@@ -1,7 +1,7 @@
 ---
 title: "The Periodic Table of Elements"
-source: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/index.md
 ---
 
 <style type="text/css">

--- a/source/elements/new/index.md
+++ b/source/elements/new/index.md
@@ -1,8 +1,8 @@
 ---
 title: Add a New Element
 description: Submit your contribution for inclusion in the Periodic Table!
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/new/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/new/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/new/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/new/index.md
 ---
 
 People wishing to submit new Elements should first propose their idea or document to [the Sidechains mailing list][sidechains-dev].  After discussion, they should submit a pull request to modify [the Periodic Table of Elements][periodic-table] to include the new Element.

--- a/source/elements/opcodes/index.md
+++ b/source/elements/opcodes/index.md
@@ -2,8 +2,8 @@
 title: New Opcodes
 description: Introduces DETERMINISTICRANDOM and CHECKSIGFROMSTACK, in addition to re-enabling several scripts previously enabled in Bitcoin.
 image: /img/new-opcodes.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/opcodes/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/opcodes/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/opcodes/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/opcodes/index.md
 ---
 
 *Principal Investigator: Patrick Strateman*

--- a/source/elements/relative-lock-time/index.md
+++ b/source/elements/relative-lock-time/index.md
@@ -2,8 +2,8 @@
 title: Relative Lock Time
 description: Allows a transaction to be time-locked, preventing its use in a new transaction until a relative time change is achieved.
 image: /img/time-lock.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/relative-lock-time/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/relative-lock-time/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/relative-lock-time/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/relative-lock-time/index.md
 ---
 
 *Principal Investigator: Mark Friedenbach*

--- a/source/elements/schnorr-signatures/index.md
+++ b/source/elements/schnorr-signatures/index.md
@@ -2,8 +2,8 @@
 title: Schnorr Signature Validation
 description: A new way of constructing signatures for transactions, both improving efficiency of validating a transaction and offering new modes of multi-signature.
 image: /img/confidential-transactions.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/schnorr-signatures/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/schnorr-signatures/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/schnorr-signatures/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/schnorr-signatures/index.md
 ---
 
 *Principal Investigator: Patrick Strateman*

--- a/source/elements/segregated-witness/index.md
+++ b/source/elements/segregated-witness/index.md
@@ -2,8 +2,8 @@
 title: Segregated Witness
 description: Reduce the required space for transactions in a block by a factor of 4.
 image: /img/segregated-witness.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/segregated-witness/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/segregated-witness/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/segregated-witness/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/segregated-witness/index.md
 ---
 
 *Principal Investigator: Pieter Wuille*

--- a/source/elements/signature-covers-value/index.md
+++ b/source/elements/signature-covers-value/index.md
@@ -2,8 +2,8 @@
 title: Signature Covers Value
 description: This allows the signature on a transaction to be invalidated if the inputs have been spent, making it faster and easier to validate a transaction, simply by checking its signature.
 image: /img/signature-covers-value.svg
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/elements/signature-covers-value/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/signature-covers-value/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/signature-covers-value/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/signature-covers-value/index.md
 ---
 
 *Principal Investigator: Glenn Willen*

--- a/source/elements/signed-blocks/index.md
+++ b/source/elements/signed-blocks/index.md
@@ -3,8 +3,8 @@ title: Signed Blocks
 description: Blocks can be cryptographically signed, allowing the creator of the block to verify their identity in the future.
 image: /img/signed-blocks.svg
 branch: block-signing-0.10
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/relaunch/source/elements/signed-blocks/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/relaunch/source/elements/signed-blocks/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/elements/signed-blocks/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/elements/signed-blocks/index.md
 ---
 
 *Principal Investigator: Jorge Timón*

--- a/source/sidechains/alpha/index.md
+++ b/source/sidechains/alpha/index.md
@@ -1,7 +1,7 @@
 ---
 title: The Alpha Sidechain
-edit: https://github.com/ElementsProject/elementsproject.github.io/blob/hexo/source/sidechains/alpha/index.md
-source: https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/sidechains/alpha/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/sidechains/alpha/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/sidechains/alpha/index.md
 ---
 
 To make it easy for the community to test the latest Elements, this project

--- a/source/sidechains/index.md
+++ b/source/sidechains/index.md
@@ -1,8 +1,8 @@
 ---
 title: Sidechains
 description: Combine multiple Elements into your own sidechain.
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/relaunch/source/sidechains/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/relaunch/source/sidechains/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/sidechains/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/sidechains/index.md
 ---
 
 

--- a/source/sidechains/liquid/index.md
+++ b/source/sidechains/liquid/index.md
@@ -1,7 +1,7 @@
 ---
 title: Liquid
-source: https://github.com/ElementsProject/elementsproject.github.io/blob/relaunch/source/sidechains/liquid/index.md
-edit: https://github.com/ElementsProject/elementsproject.github.io/edit/relaunch/source/sidechains/liquid/index.md
+source: https://github.com/ElementsProject/elementsproject.github.io/blob/master/source/sidechains/liquid/index.md
+edit: https://github.com/ElementsProject/elementsproject.github.io/edit/master/source/sidechains/liquid/index.md
 data:
   elements: ct
 ---


### PR DESCRIPTION
Many pages on the site have a nice "Edit this page|View the source" buttons, but different buttons lead to different branches (and none of these branches is master).  For example:

- **hexo branch:** https://elementsproject.org/elements/ links to
https://github.com/ElementsProject/elementsproject.github.io/edit/hexo/source/elements/index.md 

- **relaunch branch:** https://elementsproject.org/sidechains/ links to https://github.com/ElementsProject/elementsproject.github.io/edit/relaunch/source/sidechains/index.md

This commit changes `hexo` and `relaunch` to `master`.  The `sed -i` command used is provided in the commit message.