### PR TITLE
Add redirect links within pages for old content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,8 @@ title: elementsproject.org
 description: >- # this means to ignore newlines
   Elements - an open source, sidechain-capable blockchain platform.
 
+plugins:
+  - jekyll-redirect-from
 
 web_github_link: https://github.com/ElementsProject/elementsproject.github.io
 elements_github_link: https://github.com/ElementsProject/elements

--- a/blockchain-or-sidechain/index.md
+++ b/blockchain-or-sidechain/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Blockchain or Sidechain?
 permalink: /blockchain-or-sidechain
+redirect_from: /sidechains
 ---
 # The correct approach to deploying a solution built on Elements
 
@@ -41,4 +42,8 @@ When should you use a blockchain as a solution?
 
 **Deciding if a blockchain is an appropriate way to deliver your project is a very important process as Blockchains only provide solutions to very specific types of problem.**
 
-[Next: Learn Elements by following the code tutorial]({{ site.url }}/elements-code-tutorial/overview)
+### In the Code Tutorial
+
+Learn how to run Elements as a [standalone blockchain]({{ site.url }}/elements-code-tutorial/blockchain)
+
+Learn how to run Elements as a [sidechain]({{ site.url }}/elements-code-tutorial/sidechain)

--- a/community/index.md
+++ b/community/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Join the Elements commnity
 permalink: /community
+redirect_from: /contributing
 ---
 # Join the Elements community and contribute to the project
 

--- a/elements-code-tutorial/sidechain.md
+++ b/elements-code-tutorial/sidechain.md
@@ -2,6 +2,7 @@
 layout: page
 title: Elements Sidechain
 permalink: /elements-code-tutorial/sidechain
+redirect_from: /sidechains/creating-your-own
 ---
 
 # Elements code tutorial

--- a/features/confidential-transactions/addresses.md
+++ b/features/confidential-transactions/addresses.md
@@ -2,6 +2,7 @@
 layout: page
 title: Confidential Transactions - Addresses
 permalink: features/confidential-transactions/addresses
+redirect_from: /elements/confidential-transactions/addresses
 ---
 
 # Confidential Transactions - Confidential Addresses

--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Confidential Transactions
 permalink: features/confidential-transactions
+redirect_from: elements/confidential-transactions
 ---
 
 # Confidential Transactions

--- a/features/confidential-transactions/investigation.md
+++ b/features/confidential-transactions/investigation.md
@@ -2,6 +2,7 @@
 layout: page
 title: Confidential Transactions - Investigation
 permalink: features/confidential-transactions/investigation
+redirect_from: /elements/confidential-transactions/investigation
 ---
 
 # Confidential Transactions - Investigation

--- a/features/issued-assets/index.md
+++ b/features/issued-assets/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Issued Assets
 permalink: features/issued-assets
+redirect_from: /elements/asset-issuance
 ---
 
 #  Issued Assets

--- a/features/issued-assets/investigation.md
+++ b/features/issued-assets/investigation.md
@@ -2,6 +2,7 @@
 layout: page
 title: Issued Assets - Investigation
 permalink: features/issued-assets/investigation
+redirect_from: /elements/issued-assets/investigation
 ---
 
 #  Issued Assets - Investigation

--- a/features/opcodes/index.md
+++ b/features/opcodes/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Additional opcodes
 permalink: features/opcodes
+redirect_from: /elements/opcodes
 ---
 
 #  Additional opcodes

--- a/how-it-works/index.md
+++ b/how-it-works/index.md
@@ -2,6 +2,9 @@
 layout: page
 title: How it works
 permalink: /how-it-works
+redirect_from: 
+  - /elements/deterministic-pegs
+  - /elements/signed-blocks
 ---
 
 # How Elements works and the roles of network participants


### PR DESCRIPTION
e.g. 

https://elementsproject.org/elements/confidential-transactions 

will redirect to:

https://elementsproject.org/features/confidential-transactions 