### PR TITLE
Added end slash to redirect paths

### DIFF
--- a/blockchain-or-sidechain/index.md
+++ b/blockchain-or-sidechain/index.md
@@ -2,7 +2,9 @@
 layout: page
 title: Blockchain or Sidechain?
 permalink: /blockchain-or-sidechain
-redirect_from: /sidechains
+redirect_from:
+  - /sidechains/
+  - /sidechains
 ---
 # The correct approach to deploying a solution built on Elements
 

--- a/community/index.md
+++ b/community/index.md
@@ -2,7 +2,9 @@
 layout: page
 title: Join the Elements commnity
 permalink: /community
-redirect_from: /contributing
+redirect_from:
+  - /contributing/
+  - /contributing
 ---
 # Join the Elements community and contribute to the project
 

--- a/elements-code-tutorial/sidechain.md
+++ b/elements-code-tutorial/sidechain.md
@@ -2,7 +2,9 @@
 layout: page
 title: Elements Sidechain
 permalink: /elements-code-tutorial/sidechain
-redirect_from: /sidechains/creating-your-own
+redirect_from:
+  - /sidechains/creating-your-own/
+  - /sidechains/creating-your-own
 ---
 
 # Elements code tutorial

--- a/features/confidential-transactions/addresses.md
+++ b/features/confidential-transactions/addresses.md
@@ -2,7 +2,9 @@
 layout: page
 title: Confidential Transactions - Addresses
 permalink: features/confidential-transactions/addresses
-redirect_from: /elements/confidential-transactions/addresses
+redirect_from:
+  - /elements/confidential-transactions/addresses/
+  - /elements/confidential-transactions/addresses
 ---
 
 # Confidential Transactions - Confidential Addresses

--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -2,7 +2,9 @@
 layout: page
 title: Confidential Transactions
 permalink: features/confidential-transactions
-redirect_from: elements/confidential-transactions
+redirect_from:
+  - /elements/confidential-transactions/
+  - /elements/confidential-transactions
 ---
 
 # Confidential Transactions

--- a/features/confidential-transactions/investigation.md
+++ b/features/confidential-transactions/investigation.md
@@ -2,7 +2,9 @@
 layout: page
 title: Confidential Transactions - Investigation
 permalink: features/confidential-transactions/investigation
-redirect_from: /elements/confidential-transactions/investigation
+redirect_from:
+  - /elements/confidential-transactions/investigation/
+  - /elements/confidential-transactions/investigation
 ---
 
 # Confidential Transactions - Investigation

--- a/features/issued-assets/index.md
+++ b/features/issued-assets/index.md
@@ -2,7 +2,9 @@
 layout: page
 title: Issued Assets
 permalink: features/issued-assets
-redirect_from: /elements/asset-issuance
+redirect_from:
+  - /elements/asset-issuance/
+  - /elements/asset-issuance
 ---
 
 #  Issued Assets

--- a/features/issued-assets/investigation.md
+++ b/features/issued-assets/investigation.md
@@ -2,7 +2,9 @@
 layout: page
 title: Issued Assets - Investigation
 permalink: features/issued-assets/investigation
-redirect_from: /elements/issued-assets/investigation
+redirect_from:
+  - /elements/issued-assets/investigation/
+  - /elements/issued-assets/investigation
 ---
 
 #  Issued Assets - Investigation

--- a/features/opcodes/index.md
+++ b/features/opcodes/index.md
@@ -2,7 +2,9 @@
 layout: page
 title: Additional opcodes
 permalink: features/opcodes
-redirect_from: /elements/opcodes
+redirect_from:
+  - /elements/opcodes/
+  - /elements/opcodes
 ---
 
 #  Additional opcodes

--- a/features/schnorr-signatures/index.md
+++ b/features/schnorr-signatures/index.md
@@ -2,7 +2,9 @@
 layout: page
 title: Schnorr Signatures (research)
 permalink: features/schnorr-signatures
-redirect_from: /elements/schnorr-signatures
+redirect_from:
+  - /elements/schnorr-signatures/
+  - /elements/schnorr-signatures
 ---
 
 #  Schnorr Signatures (research)

--- a/how-it-works/index.md
+++ b/how-it-works/index.md
@@ -3,6 +3,8 @@ layout: page
 title: How it works
 permalink: /how-it-works
 redirect_from: 
+  - /elements/deterministic-pegs/
+  - /elements/signed-blocks/
   - /elements/deterministic-pegs
   - /elements/signed-blocks
 ---


### PR DESCRIPTION
Without these links like this work:

https://elementsproject.org/elements/confidential-transactions

But this would not:

https://elementsproject.org/elements/confidential-transactions/