### PR TITLE
Remove redundant .rpcuser and .rpcpassword settings

### DIFF
--- a/elements-code-tutorial/working-environment.md
+++ b/elements-code-tutorial/working-environment.md
@@ -48,8 +48,6 @@ regtest=1
 daemon=1
 txindex=1
 
-regtest.rpcuser=user3
-regtest.rpcpassword=password3
 regtest.rpcport=18888
 regtest.port=18889
 


### PR DESCRIPTION
These are not needed for regtest config settings as left unqualified they will apply to all environments.