### PR TITLE
Fix a link to code tutorial

### DIFF
--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -25,7 +25,7 @@ You can also read Gregory Maxwell's [initial investigation]({{ site.url }}/featu
 
 ### Using Confidential Transactions in Elements
 
-For a detailed look at using Confidential Transactions please refer to the Confidential Transactions section of the [code tutorial]({{ site.url }}/features/confidential-transactions). 
+For a detailed look at using Confidential Transactions please refer to the Confidential Transactions section of the [code tutorial]({{ site.url }}/elements-code-tutorial/confidential-transactions). 
 
 At a high-level, the transaction flow is very similar to Bitcoin's on the surface. 
 


### PR DESCRIPTION
The "code tutorial" link in the "Using Confidential Transactions in Elements" section was pointing at this same page, and not at the code tutorial page.