### PR TITLE
Removed unrequired qt dependancies

### DIFF
--- a/elements-code-tutorial/installing-elements.md
+++ b/elements-code-tutorial/installing-elements.md
@@ -30,7 +30,6 @@ Before we can compile and install Elements, we need to install software that the
 ~~~~
 sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev
 sudo apt-get install libboost-all-dev
-sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
 sudo apt-get install libqrencode-dev autoconf openssl libssl-dev libevent-dev
 sudo apt-get install libminiupnpc-dev
 sudo apt-get install libdb4.8-dev libdb4.8++-dev
@@ -49,7 +48,7 @@ Now let's configure, compile and install Elements. If you get a permission denie
 
 ~~~~
 ./autogen.sh
-./configure
+./configure --without-gui
 make
 make install
 ~~~~


### PR DESCRIPTION
As there is no elements qt at the minute and the 0.17 build has failed to compile on a few machines with qt related issues I think it best to remove what were non-required dependencies anyway - and add the --without-gui flag.

Addresses Issue #79 