### PR TITLE
Rename folder ref for asset registry

### DIFF
--- a/elements-code-tutorial/advanced-examples.md
+++ b/elements-code-tutorial/advanced-examples.md
@@ -531,7 +531,7 @@ if [ "BAR" = $EXAMPLETYPE ] || [ "ALL" = $EXAMPLETYPE ] ; then
 	# can use for this.
 	
 	# Write the domain and asset ownership proof to a file. 
-	# The file should then be placed in a directory named ".well_known"
+	# The file should then be placed in a directory named ".well-known"
 	# within the root of your domain. The file should have no extension
 	# and just copied as it is created.
 	


### PR DESCRIPTION
It was wrongly labelled in the asset reg repo - testing failed because of this so renaming to right path.