### PR TITLE
Added Berkeley build from source

### DIFF
--- a/elements-code-tutorial/installing-bitcoin.md
+++ b/elements-code-tutorial/installing-bitcoin.md
@@ -10,7 +10,9 @@ permalink: /elements-code-tutorial/installing-bitcoin
 
 First we will install Bitcoin on the machine. This will allow us to demonstrate how the Federated 2-Way Peg works in Elements later on in the tutorial. It is not required if you intend to use Elements as a standalone blockchain, but to fully understand the features available in Elements it is a good idea to follow along anyway. It doesn’t take long to install Bitcoin using the commands below and we will be running in "regtest" mode, so there is no blockchain to sync.
 
-We will be using the [Bitcoin PPA for ubuntu](https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin) but you can also compile it from source by following instructions on the [Bitcoin Core repository](https://github.com/bitcoin/bitcoin). Open a new terminal window and run the following `terminal commands` one after the other:
+For ease of use, we will be using the [Bitcoin PPA for ubuntu](https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin). It should be noted that the PPA is now marked as no longer being supported, so you may prefer to follow the instructions on the [Bitcoin Core repository](https://github.com/bitcoin/bitcoin) and compile Bitcoin Core from source. If you experience issues relating to the Berkeley database during Bitcoin build configuration, follow the Berkeley install steps from the [Installing Elements]({{ site.url }}/elements-code-tutorial/installing-elements) section.
+
+Assuming you choose to use the PPA, open a new terminal window and run the following `terminal commands` one after the other:
 
 ~~~~
 sudo apt-add-repository ppa:bitcoin/bitcoin

--- a/elements-code-tutorial/installing-elements.md
+++ b/elements-code-tutorial/installing-elements.md
@@ -33,26 +33,36 @@ sudo apt-get install libboost-all-dev
 sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler imagemagick librsvg2-bin
 sudo apt-get install libqrencode-dev autoconf openssl libssl-dev libevent-dev
 sudo apt-get install libminiupnpc-dev
-sudo apt-get install libdb4.8-dev libdb4.8++-dev
 sudo apt install jq
 ~~~~
 
-Move into the Elements directory:
+Now we need to build and install the Berkeley database.
+
+##### Note: You **must** replace ``/home/yourusername`` below with the location of your home directory. Again, note that some lines wrap in the text below.
+
+~~~~
+mkdir bdb4
+wget 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+tar -xzvf db-4.8.30.NC.tar.gz
+sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' db-4.8.30.NC/dbinc/atomic.h
+cd db-4.8.30.NC/build_unix/
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=/home/yourusername/bdb4/
+make install
+~~~~
+
+Now let's configure, compile and install Elements.
+
+##### Note: You **must** replace ``/home/yourusername`` below (which occurs twice) with the location of your home directory.
 
 ~~~~
 cd elements
-~~~~
-
-Now let's configure, compile and install Elements. If you get a permission denied error when running the final command use "sudo make install" instead.
-
-##### Note: The "make" command may take a while to complete as it will also run the Elements test-suite as part of the build process.
-
-~~~~
 ./autogen.sh
-./configure
+./configure LDFLAGS="-L/home/yourusername/bdb4/lib/" CPPFLAGS="-I/home/yourusername/bdb4/include/"
 make
-make install
+sudo make install
 ~~~~
+
+The "make" command may take a while to complete as it will also run the Elements test-suite as part of the build process.
 
 Check that the install worked:
 


### PR DESCRIPTION
As ``libdb4.8-dev`` and ``libdb4.8++-dev`` packages are no longer available we need to compile Berkeley db from source. Need to also include a patch to allow build on unbuntu - which modifies `atomic.h`.