### PR TITLE
maximum confidential amount adjustment

### DIFF
--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -90,13 +90,11 @@ elements-cli sendrawtransaction $TX
 
 The implementation of Confidential Transactions as it appears in Elements has some important limitations to be aware of.
 
-The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level.  Subsequently, there is a "minimum confidential amount" around 0.0001, and a "maximum confidential amount" that is 2<sup>32</sup> times the minimum amount.
-
-Digits smaller than the minimum will be revealed to observers; for example, if the minimum is 0.0001, a transaction output of 123.456789 will look like "?.????89". The tiny amount of information about the value leaked in this way is unlikely to be important, but be aware that this could allow observers to "follow" coins by linking subsequent transactions with identical amounts. All values can be rounded to the minimum to avoid revealing information in this way if preferred.
+The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level.  Subsequently, the default "maximum confidential amount" is just over 45 million (45,035,996.27370496). For assets that are pegged to Bitcoin, such as L-BTC on the Liquid network, it is impossible to exceed 2^52 satoshis. For other Issued Assets it may be possible to exceed the maximum confidential amount by repeatedly reissuing the asset and then spending an amount greater than the limit in a single transaction, and so the limitation should be noted.
 
 A transaction output larger than the maximum will reveal the order of magnitude of the amount to observers, and will also reveal additional digits at the bottom of the amount.
 
-For example, if the maximum is 500k, then all outputs under that amount will look the same, but an output between 500k and 5M will be visible as such to observers (but not the exact amount within that range), and will also reveal one additional digit of the low end of the amount. Revealing the range in this way could be a very significant privacy leak; splitting such extremely large transactions to keep them under the maximum confidential amount is strongly recommended.
+For example, if the maximum is 45 million, then all outputs under that amount will look the same, but an output between 45 million and 450 million will be visible as such to observers (but not the exact amount within that range), and will also reveal one additional digit of the low end of the amount. Revealing the range in this way could be a very significant privacy leak; splitting such extremely large transactions to keep them under the maximum confidential amount is strongly recommended.
 
 ### Find out more about Confidential Transactions
 

--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -90,7 +90,7 @@ elements-cli sendrawtransaction $TX
 
 The implementation of Confidential Transactions, as it appears in Elements, has some important limitations to be aware of.
 
-The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is currently 52 bits, which will cover any value up to 2^52 satoshi, which equates to a maximum amount of just over 45 million. As the maximum amount that can be transacted is inherited from Bitcoin, and set at 21 million, this currently provides cover for all asset transactions.
+The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is currently 52 bits, which will cover any value up to 2^52 satoshi, which equates to a maximum amount of just over 45 million BTC equivalent units. As the maximum amount that can be transacted is inherited from Bitcoin, and set at 21 million BTC equivalent units, this currently provides cover for all asset transactions.
 
 A transaction output larger than the maximum value set by the blinding precision will reveal the order of magnitude of the amount to observers, and will also reveal additional digits at the bottom of the amount, so care must be taken if you alter the default value.
 

--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -90,11 +90,11 @@ elements-cli sendrawtransaction $TX
 
 The implementation of Confidential Transactions as it appears in Elements has some important limitations to be aware of.
 
-The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level.  Subsequently, the default "maximum confidential amount" is just over 45 million (45,035,996.27370496). For assets that are pegged to Bitcoin, such as L-BTC on the Liquid network, it is impossible to exceed 2^52 satoshis. For other Issued Assets it may be possible to exceed the maximum confidential amount by repeatedly reissuing the asset and then spending an amount greater than the limit in a single transaction, and so the limitation should be noted.
+The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is 52-bits, which will cover any value up to 2^52 satoshi. The default equates to a maximum amount of just over 45 million. For assets that are pegged to Bitcoin, such as L-BTC on the Liquid network, this provides cover for all possible pegged asset transactions. It should be noted that for Issued Assets it is possible to exceed the default maximum confidential amount by repeatedly reissuing the asset and then spending an amount greater than the limit in a single transaction.
 
 A transaction output larger than the maximum will reveal the order of magnitude of the amount to observers, and will also reveal additional digits at the bottom of the amount.
 
-For example, if the maximum is 45 million, then all outputs under that amount will look the same, but an output between 45 million and 450 million will be visible as such to observers (but not the exact amount within that range), and will also reveal one additional digit of the low end of the amount. Revealing the range in this way could be a very significant privacy leak; splitting such extremely large transactions to keep them under the maximum confidential amount is strongly recommended.
+For example, if the user uses the default blinding precision of 52 bits, then all outputs under that amount will look the same, but an output between 45 million and 450 million will be visible as such to observers (but not the exact amount within that range), and will also reveal one additional digit of the low end of the amount. Revealing the range in this way could be a very significant privacy leak; splitting such extremely large transactions to keep them under the maximum confidential amount is strongly recommended.
 
 ### Find out more about Confidential Transactions
 

--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -90,7 +90,7 @@ elements-cli sendrawtransaction $TX
 
 The implementation of Confidential Transactions as it appears in Elements has some important limitations to be aware of.
 
-The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is 52-bits, which will cover any value up to 2^52 satoshi. The default equates to a maximum amount of just over 45 million. For assets that are pegged to Bitcoin, such as L-BTC on the Liquid network, this provides cover for all possible pegged asset transactions. It should be noted that for Issued Assets it is possible to exceed the default maximum confidential amount by repeatedly reissuing the asset and then spending an amount greater than the limit in a single transaction.
+The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is 52 bits, which will cover any value up to 2^52 satoshi. The default equates to a maximum amount of just over 45 million. For assets that are pegged to Bitcoin, such as L-BTC on the Liquid network, this provides cover for all possible pegged asset transactions. It should be noted that for Issued Assets it is possible to exceed the default maximum confidential amount by repeatedly reissuing the asset and then spending an amount greater than the limit in a single transaction.
 
 A transaction output larger than the maximum will reveal the order of magnitude of the amount to observers, and will also reveal additional digits at the bottom of the amount.
 

--- a/features/confidential-transactions/index.md
+++ b/features/confidential-transactions/index.md
@@ -88,13 +88,13 @@ elements-cli sendrawtransaction $TX
 
 ### Limitations
 
-The implementation of Confidential Transactions as it appears in Elements has some important limitations to be aware of.
+The implementation of Confidential Transactions, as it appears in Elements, has some important limitations to be aware of.
 
-The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is 52 bits, which will cover any value up to 2^52 satoshi. The default equates to a maximum amount of just over 45 million. For assets that are pegged to Bitcoin, such as L-BTC on the Liquid network, this provides cover for all possible pegged asset transactions. It should be noted that for Issued Assets it is possible to exceed the default maximum confidential amount by repeatedly reissuing the asset and then spending an amount greater than the limit in a single transaction.
+The implementation only hides a certain number of the digits of the amount of each transaction output, dependent on the range proof's "blinding coverage" at a desired precision level. The default blinding precision is currently 52 bits, which will cover any value up to 2^52 satoshi, which equates to a maximum amount of just over 45 million. As the maximum amount that can be transacted is inherited from Bitcoin, and set at 21 million, this currently provides cover for all asset transactions.
 
-A transaction output larger than the maximum will reveal the order of magnitude of the amount to observers, and will also reveal additional digits at the bottom of the amount.
+A transaction output larger than the maximum value set by the blinding precision will reveal the order of magnitude of the amount to observers, and will also reveal additional digits at the bottom of the amount, so care must be taken if you alter the default value.
 
-For example, if the user uses the default blinding precision of 52 bits, then all outputs under that amount will look the same, but an output between 45 million and 450 million will be visible as such to observers (but not the exact amount within that range), and will also reveal one additional digit of the low end of the amount. Revealing the range in this way could be a very significant privacy leak; splitting such extremely large transactions to keep them under the maximum confidential amount is strongly recommended.
+For example, if a user chooses a lower blinding precision than the default in their own Elements implementation, or an increased maximum transaction amount, then all outputs under the limit will look the same, but an output over the amount will be visible as such to observers. Although the exact amount will not be revealed, the order or magnitue over the maximum will. Revealing the range in this way could be a very significant privacy leak; splitting such extremely large transactions to keep them under the maximum confidential amount is strongly recommended.
 
 ### Find out more about Confidential Transactions
 


### PR DESCRIPTION
Since increasing the default ct_bits to 52 from 38, the new “maximum confidential amount” is just over 45 million (BTC units).