### PR TITLE
Have other node derive address so it can see issuance/reissuance

### DIFF
--- a/elements-code-tutorial/easy-run-code.md
+++ b/elements-code-tutorial/easy-run-code.md
@@ -230,9 +230,10 @@ e1-cli generatetoaddress 1 $ADDRGEN1
 sleep 10
 e2-cli listissuances
 
-IADDR=$(e1-cli gettransaction $ITXID | jq -r '.details[0].address')
-
-e2-cli importaddress $IADDR
+ISSUE_RAW_TX=$(e2-cli getrawtransaction $ITXID 1)
+ISSUE_VOUTS=$(echo $ISSUE_RAW_TX | jq -r '.vout')
+VOUT_ADDRESS_ISSUE=$(echo $ISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+e2-cli importaddress $VOUT_ADDRESS_ISSUE
 
 e2-cli listissuances
 
@@ -301,9 +302,11 @@ sleep 10
 e1-cli listissuances
 
 RITXID=$(echo $RISSUE | jq -r '.txid')
-RIADDR=$(e2-cli gettransaction $RITXID | jq -r '.details[0].address')
+REISSUE_RAW_TX=$(e1-cli getrawtransaction $RITXID 1)
+REISSUE_VOUTS=$(echo $REISSUE_RAW_TX | jq -r '.vout')
+VOUT_ADDRESS_REISSUE=$(echo $REISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+e1-cli importaddress $VOUT_ADDRESS_REISSUE
 
-e1-cli importaddress $RIADDR
 e1-cli listissuances
 
 UBRISSUE=$(e2-cli issueasset 55 1 false)
@@ -318,10 +321,10 @@ sleep 10
 e1-cli listissuances
 
 UBRITXID=$(echo $UBRISSUE | jq -r '.txid')
-
-UBRIADDR=$(e2-cli gettransaction $UBRITXID | jq -r '.details[0].address')
-
-e1-cli importaddress $UBRIADDR
+UBREISSUE_RAW_TX=$(e1-cli getrawtransaction $UBRITXID 1)
+UBREISSUE_VOUTS=$(echo $UBREISSUE_RAW_TX | jq -r '.vout')
+UBVOUT_ADDRESS_REISSUE=$(echo $UBREISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+e1-cli importaddress $UBVOUT_ADDRESS_REISSUE
 
 e1-cli listissuances
 

--- a/elements-code-tutorial/easy-run-code.md
+++ b/elements-code-tutorial/easy-run-code.md
@@ -230,10 +230,14 @@ e1-cli generatetoaddress 1 $ADDRGEN1
 sleep 10
 e2-cli listissuances
 
-ISSUE_RAW_TX=$(e2-cli getrawtransaction $ITXID 1)
-ISSUE_VOUTS=$(echo $ISSUE_RAW_TX | jq -r '.vout')
-VOUT_ADDRESS_ISSUE=$(echo $ISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
-e2-cli importaddress $VOUT_ADDRESS_ISSUE
+IADDR=$(e1-cli gettransaction $ITXID | jq -r '.details[0].address')
+e2-cli importaddress $IADDR
+
+# Or if the address is not known to e2 but the TXID is (requires index=1 in config file to work):
+#ISSUE_RAW_TX=$(e2-cli getrawtransaction $ITXID 1)
+#ISSUE_VOUTS=$(echo $ISSUE_RAW_TX | jq -r '.vout')
+#VOUT_ADDRESS_ISSUE=$(echo $ISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+#e2-cli importaddress $VOUT_ADDRESS_ISSUE
 
 e2-cli listissuances
 
@@ -302,10 +306,14 @@ sleep 10
 e1-cli listissuances
 
 RITXID=$(echo $RISSUE | jq -r '.txid')
-REISSUE_RAW_TX=$(e1-cli getrawtransaction $RITXID 1)
-REISSUE_VOUTS=$(echo $REISSUE_RAW_TX | jq -r '.vout')
-VOUT_ADDRESS_REISSUE=$(echo $REISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
-e1-cli importaddress $VOUT_ADDRESS_REISSUE
+RIADDR=$(e2-cli gettransaction $RITXID | jq -r '.details[0].address')
+e1-cli importaddress $RIADDR
+
+# Or if the address is not known to e1 but the TXID is (requires index=1 in config file to work):
+#REISSUE_RAW_TX=$(e1-cli getrawtransaction $RITXID 1)
+#REISSUE_VOUTS=$(echo $REISSUE_RAW_TX | jq -r '.vout')
+#VOUT_ADDRESS_REISSUE=$(echo $REISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+#e1-cli importaddress $VOUT_ADDRESS_REISSUE
 
 e1-cli listissuances
 
@@ -321,10 +329,15 @@ sleep 10
 e1-cli listissuances
 
 UBRITXID=$(echo $UBRISSUE | jq -r '.txid')
-UBREISSUE_RAW_TX=$(e1-cli getrawtransaction $UBRITXID 1)
-UBREISSUE_VOUTS=$(echo $UBREISSUE_RAW_TX | jq -r '.vout')
-UBVOUT_ADDRESS_REISSUE=$(echo $UBREISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
-e1-cli importaddress $UBVOUT_ADDRESS_REISSUE
+
+UBRIADDR=$(e2-cli gettransaction $UBRITXID | jq -r '.details[0].address')
+e1-cli importaddress $UBRIADDR
+
+# Or if the address is not known to e1 but the TXID is (requires index=1 in config file to work):
+#UBREISSUE_RAW_TX=$(e1-cli getrawtransaction $UBRITXID 1)
+#UBREISSUE_VOUTS=$(echo $UBREISSUE_RAW_TX | jq -r '.vout')
+#UBVOUT_ADDRESS_REISSUE=$(echo $UBREISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+#e1-cli importaddress $UBVOUT_ADDRESS_REISSUE
 
 e1-cli listissuances
 

--- a/elements-code-tutorial/issuing-assets.md
+++ b/elements-code-tutorial/issuing-assets.md
@@ -134,11 +134,13 @@ Then wait a few seconds before having Bob's wallet list its view of the asset is
 e2-cli listissuances
 ~~~~
 
-Bob's wallet isn't aware of the issuance, so we'll import the address into his wallet:
+Bob's wallet isn't aware of the issuance transaction's details, so we'll import an address that was part of the issuance transaction outputs into his wallet as watch-only. It doesn't matter which address is used, so we will use the first instance:
 
 ~~~~
-IADDR=$(e1-cli gettransaction $ITXID | jq -r '.details[0].address')
-e2-cli importaddress $IADDR
+ISSUE_RAW_TX=$(e2-cli getrawtransaction $ITXID 1)
+ISSUE_VOUTS=$(echo $ISSUE_RAW_TX | jq -r '.vout')
+VOUT_ADDRESS_ISSUE=$(echo $ISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+e2-cli importaddress $VOUT_ADDRESS_ISSUE
 ~~~~
 
 If we try and view the list of issuances from Bob's node now we'll see the issuance, but notice that the amount of the asset and the amount of its associated token are hidden:

--- a/elements-code-tutorial/issuing-assets.md
+++ b/elements-code-tutorial/issuing-assets.md
@@ -134,7 +134,16 @@ Then wait a few seconds before having Bob's wallet list its view of the asset is
 e2-cli listissuances
 ~~~~
 
-Bob's wallet isn't aware of the issuance transaction's details, so we'll import an address that was part of the issuance transaction outputs into his wallet as watch-only. It doesn't matter which address is used, so we will use the first instance:
+Bob's wallet isn't aware of the issuance transaction's details, so we'll import an address that was part of the issuance transaction output into his wallet as watch-only. 
+
+~~~~
+IADDR=$(e1-cli gettransaction $ITXID | jq -r '.details[0].address')
+e2-cli importaddress $IADDR
+~~~~
+
+Another way to make Bob's node aware of the issuance is for Bob to get the issuance transaction ID and use that to import any output address from the transaction into his wallet. This is useful if Bob is not able to get the adress from Alice, but knows the transaction in which the asset was issued... perhaps by using the [Blockstream Explorer's assets list](https://blockstream.info/liquid/assets/) to look it up. From that page he can either use the TXID or select one of the addresses from the outputs. Using the TXID requires that Bob's node has ``index=1`` set in the elements.conf file.
+
+Bob's already imported the address above but for reference the code to import using TXID is shown below. It doesn't matter which address is used, so we will use the first instance:
 
 ~~~~
 ISSUE_RAW_TX=$(e2-cli getrawtransaction $ITXID 1)
@@ -143,7 +152,7 @@ VOUT_ADDRESS_ISSUE=$(echo $ISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
 e2-cli importaddress $VOUT_ADDRESS_ISSUE
 ~~~~
 
-If we try and view the list of issuances from Bob's node now we'll see the issuance, but notice that the amount of the asset and the amount of its associated token are hidden:
+Either way, if we try and view the list of issuances from Bob's node now we'll see the issuance, but notice that the amount of the asset and the amount of its associated token are hidden:
 
 ~~~~
 e2-cli listissuances

--- a/elements-code-tutorial/reissuing-assets.md
+++ b/elements-code-tutorial/reissuing-assets.md
@@ -166,8 +166,10 @@ Import the address so that it can:
 
 ~~~~
 RITXID=$(echo $RISSUE | jq -r '.txid')
-RIADDR=$(e2-cli gettransaction $RITXID | jq -r '.details[0].address')
-e1-cli importaddress $RIADDR
+REISSUE_RAW_TX=$(e1-cli getrawtransaction $RITXID 1)
+REISSUE_VOUTS=$(echo $REISSUE_RAW_TX | jq -r '.vout')
+VOUT_ADDRESS_REISSUE=$(echo $REISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+e1-cli importaddress $VOUT_ADDRESS_REISSUE
 ~~~~
 
 Now Alice's wallet can see the reissuance:
@@ -197,8 +199,10 @@ And this time if we import the address into Alice's wallet she should be able to
 e2-cli generatetoaddress 1 $ADDRGEN2
 e1-cli listissuances
 UBRITXID=$(echo $UBRISSUE | jq -r '.txid')
-UBRIADDR=$(e2-cli gettransaction $UBRITXID | jq -r '.details[0].address')
-e1-cli importaddress $UBRIADDR
+UBREISSUE_RAW_TX=$(e1-cli getrawtransaction $UBRITXID 1)
+UBREISSUE_VOUTS=$(echo $UBREISSUE_RAW_TX | jq -r '.vout')
+UBVOUT_ADDRESS_REISSUE=$(echo $UBREISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
+e1-cli importaddress $UBVOUT_ADDRESS_REISSUE
 ~~~~
 
 We can now see that Alice's wallet can see both the issuance and the amount issued (55) without the need to import the blinding key:

--- a/elements-code-tutorial/reissuing-assets.md
+++ b/elements-code-tutorial/reissuing-assets.md
@@ -166,13 +166,21 @@ Import the address so that it can:
 
 ~~~~
 RITXID=$(echo $RISSUE | jq -r '.txid')
+RIADDR=$(e2-cli gettransaction $RITXID | jq -r '.details[0].address')
+e1-cli importaddress $RIADDR
+~~~~
+
+Or if, for whatever reason, the address is not known to Alice but the TXID is (requires index=1 in config file to work):
+
+~~~~
+RITXID=$(echo $RISSUE | jq -r '.txid')
 REISSUE_RAW_TX=$(e1-cli getrawtransaction $RITXID 1)
 REISSUE_VOUTS=$(echo $REISSUE_RAW_TX | jq -r '.vout')
 VOUT_ADDRESS_REISSUE=$(echo $REISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
 e1-cli importaddress $VOUT_ADDRESS_REISSUE
 ~~~~
 
-Now Alice's wallet can see the reissuance:
+Either way, now Alice's wallet can see the reissuance:
 
 ~~~~
 e1-cli listissuances
@@ -199,13 +207,23 @@ And this time if we import the address into Alice's wallet she should be able to
 e2-cli generatetoaddress 1 $ADDRGEN2
 e1-cli listissuances
 UBRITXID=$(echo $UBRISSUE | jq -r '.txid')
+UBRIADDR=$(e2-cli gettransaction $UBRITXID | jq -r '.details[0].address')
+e1-cli importaddress $UBRIADDR
+~~~~
+
+Or if, for whatever reason, the address is not known to Alice but the TXID is (requires index=1 in config file to work):
+
+~~~~
+e2-cli generatetoaddress 1 $ADDRGEN2
+e1-cli listissuances
+UBRITXID=$(echo $UBRISSUE | jq -r '.txid')
 UBREISSUE_RAW_TX=$(e1-cli getrawtransaction $UBRITXID 1)
 UBREISSUE_VOUTS=$(echo $UBREISSUE_RAW_TX | jq -r '.vout')
 UBVOUT_ADDRESS_REISSUE=$(echo $UBREISSUE_VOUTS | jq -r '.[0].scriptPubKey.addresses[0]')
 e1-cli importaddress $UBVOUT_ADDRESS_REISSUE
 ~~~~
 
-We can now see that Alice's wallet can see both the issuance and the amount issued (55) without the need to import the blinding key:
+Either way, we can now see that Alice's wallet can see both the issuance and the amount issued (55) without the need to import the blinding key:
 
 ~~~~
 e1-cli listissuances


### PR DESCRIPTION
It's not realistic to have the issuer (or reissuer) share an address with someone who wants to view issuance details - more likely the person needing details will look up a txid. This change shows how to derive an address form tha tx and import that so the details are known by the wallet.