### PR TITLE
make tutorial 0.21 compatible

### DIFF
--- a/elements-code-tutorial/block-creation.md
+++ b/elements-code-tutorial/block-creation.md
@@ -78,6 +78,15 @@ e1-dae ${SIGNBLOCKARGS[@]}
 e2-dae ${SIGNBLOCKARGS[@]}
 ~~~~
 
+Now we need to create default wallets and rescan the blockchain:
+
+~~~
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
+~~~
+
 Now import the signing keys that we stored earlier before wiping the wallets: 
 
 ~~~~

--- a/elements-code-tutorial/blockchain.md
+++ b/elements-code-tutorial/blockchain.md
@@ -64,6 +64,15 @@ e1-dae ${STANDALONEARGS[@]}
 e2-dae ${STANDALONEARGS[@]}
 ~~~~
 
+Now we need to create default wallets and rescan the blockchain:
+
+~~~
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
+~~~
+
 We'll look at what these parameters do in more detail next.
 
 * * * 
@@ -125,7 +134,7 @@ Note that we did not need to specify the asset being sent, as "newasset" will be
 Now claim the anyone-can-spend reissuance token and generate some blocks to confirm the transactions. We also need to recreate the generate receiving addresses, because we deleted the corresponding wallets above.
 
 ~~~~
-e1-cli sendtoaddress $(e1-cli getnewaddress) 2 "" "" false false 1 UNSET $DEFAULTRIT
+e1-cli sendtoaddress $(e1-cli getnewaddress) 2 "" "" false false 1 UNSET false $DEFAULTRIT
 ADDRGEN1=$(e1-cli getnewaddress)
 ADDRGEN2=$(e2-cli getnewaddress)
 e1-cli generatetoaddress 101 $ADDRGEN1
@@ -142,7 +151,7 @@ e1-cli sendtoaddress $(e2-cli getnewaddress) 500 "" "" false
 Send some of the reissuance tokens to e2 and confirm the two transactions:
 
 ~~~~
-e1-cli sendtoaddress $(e2-cli getnewaddress) 1 "" "" false false 1 UNSET $DEFAULTRIT
+e1-cli sendtoaddress $(e2-cli getnewaddress) 1 "" "" false false 1 UNSET false $DEFAULTRIT
 e1-cli generatetoaddress 101 $ADDRGEN1
 ~~~~
 

--- a/elements-code-tutorial/easy-run-code.md
+++ b/elements-code-tutorial/easy-run-code.md
@@ -91,9 +91,58 @@ echo "The following 3 'rm' commands may error - that is fine."
 rm -r ~/bitcoindir ; rm -r ~/elementsdir1 ; rm -r ~/elementsdir2
 mkdir ~/bitcoindir ; mkdir ~/elementsdir1 ; mkdir ~/elementsdir2
 
-cp ~/elements/contrib/assets_tutorial/bitcoin.conf ~/bitcoindir/bitcoin.conf
-cp ~/elements/contrib/assets_tutorial/elements1.conf ~/elementsdir1/elements.conf
-cp ~/elements/contrib/assets_tutorial/elements2.conf ~/elementsdir2/elements.conf
+echo "regtest=1
+txindex=1
+daemon=1
+rpcuser=user3
+rpcpassword=password3
+fallbackfee=0.0002
+[regtest]
+rpcport=18888
+port=18889
+
+" > ~/bitcoindir/bitcoin.conf
+
+echo "chain=elementsregtest
+rpcuser=user1
+rpcpassword=password1
+daemon=1
+server=1
+listen=1
+txindex=1
+validatepegin=1
+mainchainrpcport=18888
+mainchainrpcuser=user3
+mainchainrpcpassword=password3
+initialfreecoins=2100000000000000
+fallbackfee=0.0002
+[elementsregtest]
+rpcport=18884
+port=18886
+anyonecanspendaremine=1
+connect=localhost:18887
+
+" > ~/elementsdir1/elements.conf
+
+echo "chain=elementsregtest
+rpcuser=user2
+rpcpassword=password2
+daemon=1
+server=1
+listen=1
+txindex=1
+mainchainrpcport=18888
+mainchainrpcuser=user3
+mainchainrpcpassword=password3
+initialfreecoins=2100000000000000
+fallbackfee=0.0002
+[elementsregtest]
+rpcport=18885
+port=18887
+anyonecanspendaremine=1
+connect=localhost:18886
+
+" > ~/elementsdir2/elements.conf
 
 b-dae
 
@@ -110,6 +159,12 @@ e1-dae
 e2-dae
 
 sleep 10
+
+# Create new wallets
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
 
 # Wait for e1 node to finish startup and respond to commands
 until e1-cli getwalletinfo
@@ -248,7 +303,7 @@ e2-cli importissuanceblindingkey $ITXID $IVIN $ISSUEKEY
 e2-cli listissuances
 
 E2DEMOADD=$(e2-cli getnewaddress)
-e1-cli sendtoaddress $E2DEMOADD 10 "" "" false false 1 UNSET demoasset
+e1-cli sendtoaddress $E2DEMOADD 10 "" "" false false 1 UNSET false demoasset
 sleep 10
 e1-cli generatetoaddress 1 $ADDRGEN1
 sleep 10
@@ -257,7 +312,7 @@ e2-cli getwalletinfo
 e1-cli getwalletinfo
 
 E1DEMOADD=$(e1-cli getnewaddress)
-e2-cli sendtoaddress $E1DEMOADD 10 "" "" false false 1 UNSET $ASSET
+e2-cli sendtoaddress $E1DEMOADD 10 "" "" false false 1 UNSET false $ASSET
 sleep 10
 e2-cli generatetoaddress 1 $ADDRGEN2
 sleep 10
@@ -291,7 +346,7 @@ e2-cli reissueasset $ASSET 10
 set -o errexit
 
 RITRECADD=$(e2-cli getnewaddress)
-e1-cli sendtoaddress $RITRECADD 1 "" "" false false 1 UNSET $TOKEN
+e1-cli sendtoaddress $RITRECADD 1 "" "" false false 1 UNSET false $TOKEN
 e1-cli generatetoaddress 1 $ADDRGEN1
 sleep 10
 e1-cli getwalletinfo
@@ -379,6 +434,12 @@ e2-dae ${SIGNBLOCKARGS[@]}
 
 sleep 10
 
+# Create new wallets
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
+
 # Ignore error
 set +o errexit
 
@@ -454,6 +515,12 @@ FEDPEGARG="-fedpegscript=5221$(echo $PUBKEY1)21$(echo $PUBKEY2)52ae"
 e1-dae $FEDPEGARG
 e2-dae $FEDPEGARG
 sleep 10
+
+# Create new wallets
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
 
 # Ignore error
 set +o errexit
@@ -535,6 +602,12 @@ e1-dae ${STANDALONEARGS[@]}
 e2-dae ${STANDALONEARGS[@]}
 sleep 10
 
+# Create new wallets
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
+
 # Ignore error
 set +o errexit
 
@@ -571,13 +644,13 @@ echo $DEFAULTRIT
 
 e1-cli sendtoaddress $(e1-cli getnewaddress) 1000000 "" "" true
 
-e1-cli sendtoaddress $(e1-cli getnewaddress) 2 "" "" false false 1 UNSET $DEFAULTRIT
+e1-cli sendtoaddress $(e1-cli getnewaddress) 2 "" "" false false 1 UNSET false $DEFAULTRIT
 e1-cli generatetoaddress 101 $ADDRGEN1
 sleep 10
 
 e1-cli sendtoaddress $(e2-cli getnewaddress) 500 "" "" false 
 
-e1-cli sendtoaddress $(e2-cli getnewaddress) 1 "" "" false false 1 UNSET $DEFAULTRIT
+e1-cli sendtoaddress $(e2-cli getnewaddress) 1 "" "" false false 1 UNSET false $DEFAULTRIT
 e1-cli generatetoaddress 101 $ADDRGEN1
 sleep 10
 

--- a/elements-code-tutorial/issuing-assets.md
+++ b/elements-code-tutorial/issuing-assets.md
@@ -191,7 +191,7 @@ Just like any other asset in Elements, we can send our "demoasset" from Alice's 
 
 ~~~~
 E2DEMOADD=$(e2-cli getnewaddress)
-e1-cli sendtoaddress $E2DEMOADD 10 "" "" false false 1 UNSET demoasset
+e1-cli sendtoaddress $E2DEMOADD 10 "" "" false false 1 UNSET false demoasset
 e1-cli generatetoaddress 1 $ADDRGEN1
 ~~~~
 
@@ -208,7 +208,7 @@ As we didn't assign a label in Bob's node for the asset we created, it will be i
 
 ~~~~
 E1DEMOADD=$(e1-cli getnewaddress)
-e2-cli sendtoaddress $E1DEMOADD 10 "" "" false false 1 UNSET $ASSET
+e2-cli sendtoaddress $E1DEMOADD 10 "" "" false false 1 UNSET false $ASSET
 e2-cli generatetoaddress 1 $ADDRGEN2
 ~~~~
 

--- a/elements-code-tutorial/reissuing-assets.md
+++ b/elements-code-tutorial/reissuing-assets.md
@@ -119,7 +119,7 @@ RITRECADD=$(e2-cli getnewaddress)
 Send the token from Alice's wallet to Bob's new address as if it were any other asset. We'll use the hex of the token to say what type of asset we are sending and also generate a block so the transaction confirms:
 
 ~~~~
-e1-cli sendtoaddress $RITRECADD 1 "" "" false false 1 UNSET $TOKEN
+e1-cli sendtoaddress $RITRECADD 1 "" "" false false 1 UNSET false $TOKEN
 e1-cli generatetoaddress 1 $ADDRGEN1
 ~~~~
 

--- a/elements-code-tutorial/sidechain.md
+++ b/elements-code-tutorial/sidechain.md
@@ -50,6 +50,15 @@ e2-dae $FEDPEGARG
 
 ##### NOTE: The characters outside the public keys are delimiters that indicate public key and 'n of m' requirements. For example, the template for a 1-of-1 fedpegscript would be ``5121<pubkey>51ae``. When testing, you can also use the OP_TRUE script ``-fedpegscript=51`` so that you do not have to provide any pubkey values as we have above.
 
+Create the default wallet and rescan the blockchain:
+
+~~~
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
+~~~
+
 Create some generate receiving addresses (as we deleted the wallets associated with them above) and mature some outputs on each chain:
 
 ~~~~

--- a/elements-code-tutorial/working-environment.md
+++ b/elements-code-tutorial/working-environment.md
@@ -25,13 +25,69 @@ mkdir ~/elementsdir1
 mkdir ~/elementsdir2
 ~~~~
 
-We need to set up our config files now. We'll do that by copying the example configuration files contained within the elements source code into the working directories we just created. 
+We need to set up our config files now. We'll do that by writing some settings to the working directories we just created.
 
+The Bitcoin config file:
 ~~~~
-cp ~/elements/contrib/assets_tutorial/bitcoin.conf ~/bitcoindir/bitcoin.conf
-cp ~/elements/contrib/assets_tutorial/elements1.conf ~/elementsdir1/elements.conf
-cp ~/elements/contrib/assets_tutorial/elements2.conf ~/elementsdir2/elements.conf
+echo "regtest=1
+txindex=1
+daemon=1
+rpcuser=user3
+rpcpassword=password3
+fallbackfee=0.0002
+[regtest]
+rpcport=18888
+port=18889
+
+" > ~/bitcoindir/bitcoin.conf
 ~~~~
+
+Elements 1 config file:
+~~~
+echo "chain=elementsregtest
+rpcuser=user1
+rpcpassword=password1
+daemon=1
+server=1
+listen=1
+txindex=1
+validatepegin=1
+mainchainrpcport=18888
+mainchainrpcuser=user3
+mainchainrpcpassword=password3
+initialfreecoins=2100000000000000
+fallbackfee=0.0002
+[elementsregtest]
+rpcport=18884
+port=18886
+anyonecanspendaremine=1
+connect=localhost:18887
+
+" > ~/elementsdir1/elements.conf
+~~~
+
+Elements 2 config file:
+~~~
+echo "chain=elementsregtest
+rpcuser=user2
+rpcpassword=password2
+daemon=1
+server=1
+listen=1
+txindex=1
+mainchainrpcport=18888
+mainchainrpcuser=user3
+mainchainrpcpassword=password3
+initialfreecoins=2100000000000000
+fallbackfee=0.0002
+[elementsregtest]
+rpcport=18885
+port=18887
+anyonecanspendaremine=1
+connect=localhost:18886
+
+" > ~/elementsdir2/elements.conf
+~~~
 
 If you take a quick look in each of the 3 config files you will see that they contain a flag to tell the nodes to operate in "regtest" mode. They also contain RPC information such as port, username and password. The Elements config files also contain details of the Bitcoin node's RPC authentication data. They need access to this information in order to authenticate and make calls to the Bitcoin node later.
 
@@ -104,7 +160,16 @@ e1-dae
 e2-dae
 ~~~~
 
-Give them a few seconds to start up and then check they are running:
+Give them a few seconds to start up and then create the default wallets for each node. We also call rescanblockchain so the nodes are aware the new wallets can access the initial free coins set within the config files.
+
+~~~
+e1-cli createwallet ""
+e2-cli createwallet ""
+e1-cli rescanblockchain
+e2-cli rescanblockchain
+~~~
+
+Then check the balances using:
 
 ~~~~
 e1-cli getwalletinfo


### PR DESCRIPTION
To make the tutorial Elements 0.21.0 compatible we need to change to use `createwallet` then `rescanblockchain` after deleting the wallet files. We also need to add another argument to `sendtoaddress` before the asset id/name. 

As the config files in the elements repository have changed to only work with the Python examples the two elements files are now echoed to file, along with the bitcoin config file to keep it consistent.