### PR TITLE
Updated the bitcoin installation instructions

### DIFF
--- a/elements-code-tutorial/installing-bitcoin.md
+++ b/elements-code-tutorial/installing-bitcoin.md
@@ -10,7 +10,7 @@ permalink: /elements-code-tutorial/installing-bitcoin
 
 First we will install Bitcoin on the machine. This will allow us to demonstrate how the Federated 2-Way Peg works in Elements later on in the tutorial. It is not required if you intend to use Elements as a standalone blockchain, but to fully understand the features available in Elements it is a good idea to follow along anyway. It doesn’t take long to install Bitcoin using the commands below and we will be running in "regtest" mode, so there is no blockchain to sync.
 
-You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you'll download the binaries, the `SHA256SUM` and `SHA256SUM.asc`-file.
+You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you'll download the binaries, the `SHA256SUMS` and `SHA256SUMS.asc`-file.
 
 Open a terminal and change your directory the one of the files mentioned above. If you are using `~Downloads` this becomes
 
@@ -48,7 +48,7 @@ which bitcoind
 
 Which should return:
 
-<div class="console-output">/usr/bin/bitcoind</div>
+<div class="console-output">/usr/local/bin/bitcoind</div>
 
 That means that the Bitcoin software was installed. We will run it later so let’s move on with getting Elements set up.
 

--- a/elements-code-tutorial/installing-bitcoin.md
+++ b/elements-code-tutorial/installing-bitcoin.md
@@ -10,7 +10,7 @@ permalink: /elements-code-tutorial/installing-bitcoin
 
 First we will install Bitcoin on the machine. This will allow us to demonstrate how the Federated 2-Way Peg works in Elements later on in the tutorial. It is not required if you intend to use Elements as a standalone blockchain, but to fully understand the features available in Elements it is a good idea to follow along anyway. It doesn’t take long to install Bitcoin using the commands below and we will be running in "regtest" mode, so there is no blockchain to sync.
 
-You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you'll download the binaries, the `SHA256SUMS` and `SHA256SUMS.asc`-file.
+You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you download the binaries, `SHA256SUMS` and `SHA256SUMS.asc` files.
 
 Open a terminal and change your directory the one of the files mentioned above. If you are using `~Downloads` this becomes
 

--- a/elements-code-tutorial/installing-bitcoin.md
+++ b/elements-code-tutorial/installing-bitcoin.md
@@ -10,7 +10,7 @@ permalink: /elements-code-tutorial/installing-bitcoin
 
 First we will install Bitcoin on the machine. This will allow us to demonstrate how the Federated 2-Way Peg works in Elements later on in the tutorial. It is not required if you intend to use Elements as a standalone blockchain, but to fully understand the features available in Elements it is a good idea to follow along anyway. It doesn’t take long to install Bitcoin using the commands below and we will be running in "regtest" mode, so there is no blockchain to sync.
 
-You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you download the binaries, `SHA256SUMS` and `SHA256SUMS.asc` files.
+You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you download the binaries, `SHA256SUMS` and `SHA256SUMS.asc` file.
 
 Open a terminal and change your directory the one of the files mentioned above. If you are using `~Downloads` this becomes
 
@@ -18,13 +18,13 @@ Open a terminal and change your directory the one of the files mentioned above. 
 cd ~/Downloads/
 ~~~
 
-Verify the hash
+Verify the hash:
 
 ~~~
 sha256sum --ignore-missing --check SHA256SUMS
 ~~~
 
-Verify that the files are signed by a bitcoin-core maintainer.
+Verify that the download is signed by a bitcoin-core maintainer. The bitcoin-source contains a [list of reputable keys](https://github.com/bitcoin/bitcoin/blob/master/contrib/verify-commits/trusted-keys). The snippet below shows how to verify the signature for one of them.
 
 ~~~
 gpg --keyserver hkps://keys.openpgp.org --recv-keys E777299FC265DD04793070EB944D35F9AC3DB76A

--- a/elements-code-tutorial/installing-bitcoin.md
+++ b/elements-code-tutorial/installing-bitcoin.md
@@ -10,20 +10,39 @@ permalink: /elements-code-tutorial/installing-bitcoin
 
 First we will install Bitcoin on the machine. This will allow us to demonstrate how the Federated 2-Way Peg works in Elements later on in the tutorial. It is not required if you intend to use Elements as a standalone blockchain, but to fully understand the features available in Elements it is a good idea to follow along anyway. It doesn’t take long to install Bitcoin using the commands below and we will be running in "regtest" mode, so there is no blockchain to sync.
 
-For ease of use, we will be using the [Bitcoin PPA for ubuntu](https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin). It should be noted that the PPA is now marked as no longer being supported, so you may prefer to follow the instructions on the [Bitcoin Core repository](https://github.com/bitcoin/bitcoin) and compile Bitcoin Core from source. If you experience issues relating to the Berkeley database during Bitcoin build configuration, follow the Berkeley install steps from the [Installing Elements]({{ site.url }}/elements-code-tutorial/installing-elements) section.
+You can download the compiled libraries from the [Bitcoin Core Download page](https://bitcoincore.org/en/download/). Make sure you'll download the binaries, the `SHA256SUM` and `SHA256SUM.asc`-file.
 
-Assuming you choose to use the PPA, open a new terminal window and run the following `terminal commands` one after the other:
+Open a terminal and change your directory the one of the files mentioned above. If you are using `~Downloads` this becomes
 
-~~~~
-sudo apt-add-repository ppa:bitcoin/bitcoin
-sudo add-apt-repository universe
-sudo apt-get update
-sudo apt-get install bitcoind
-~~~~
+~~~
+cd ~/Downloads/
+~~~
+
+Verify the hash
+
+~~~
+sha256sum --ignore-missing --check SHA256SUMS
+~~~
+
+Verify that the files are signed by a bitcoin-core maintainer.
+
+~~~
+gpg --keyserver hkps://keys.openpgp.org --recv-keys E777299FC265DD04793070EB944D35F9AC3DB76A
+gpg --verify SHA256SUMS.asc
+~~~
+
+You might get a warning that the key is not certified. This means that to fully verify your download you should also confirm the signing key's fingerprint.
+
+The next step is to install the actual binaries. Assuming you are installing version 22.0 this becomes.
+
+~~~
+tar -xf <path-to-downloaded-file>.tar.gz
+sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-22.0/bin/*
+~~~
 
 Check that the install worked:
 
-~~~~
+~~~
 which bitcoind
 ~~~~
 


### PR DESCRIPTION
It turns out that bitcoin-core stopped maintaining the ppa.
I have updated the instructions to download form BitcoinCore instead.

This is also mentioned in  [issue 143](https://github.com/ElementsProject/elementsproject.github.io/issues/143).
