### PR TITLE
remove openssl and libssl-dev

### DIFF
--- a/elements-code-tutorial/advanced-examples.md
+++ b/elements-code-tutorial/advanced-examples.md
@@ -839,8 +839,7 @@ TOKEN_ADDR=$NEWADDR
 
 CONTRACT='{"entity":{"domain":"'$DOMAIN'"},"issuer_pubkey":"'$PUBKEY'","name":"'$NAME'","precision":'$PRECISION',"ticker":"'$TICKER'","version":'$VERSION'}'
 
-# We will hash using openssl, other options are available
-CONTRACT_HASH=$(echo -n $CONTRACT | openssl dgst -sha256 | sed 's/.*= //g')
+CONTRACT_HASH=sha256sum | awk '{ print $CONTRACT }'
 
 # Reverse the hash
 TEMP=$CONTRACT_HASH

--- a/elements-code-tutorial/installing-elements.md
+++ b/elements-code-tutorial/installing-elements.md
@@ -32,7 +32,7 @@ sudo apt-get update
 sudo apt-get install build-essential libtool autotools-dev autoconf pkg-config libssl-dev
 sudo apt-get install libboost-all-dev
 sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler imagemagick librsvg2-bin
-sudo apt-get install libqrencode-dev autoconf openssl libssl-dev libevent-dev
+sudo apt-get install libqrencode-dev autoconf libevent-dev
 sudo apt-get install libminiupnpc-dev
 sudo apt install jq
 ~~~~


### PR DESCRIPTION
I didn't see the [comment](https://github.com/ElementsProject/elementsproject.github.io/pull/158#issuecomment-1172934231) from @wtogami in the initial merge request so I have made the requested changes here.

@andreabonel - are you able to test this - on Mac?

Warren - is this the format you were expecting? I have run a few tests here and it outputs the same hash as the previous openssl command.